### PR TITLE
Add specification building workflow

### DIFF
--- a/.github/workflows/build-spec.yaml
+++ b/.github/workflows/build-spec.yaml
@@ -1,0 +1,40 @@
+name: Fetch current version and build specification
+on:
+  push:
+    branches:
+      - "master"
+jobs:
+  compile-spec:
+    runs-on: ubuntu-latest
+    name: Build specification
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            spec
+      - name: Compile LaTeX specification
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: spec/main.tex
+          work_in_root_file_dir: true
+      - name: Create Release
+        uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: release_${{ github.run_number }}
+          release_name: Release ${{ github.run_number }}
+          body: PDF release
+          draft: false
+          prerelease: false
+      - name: Upload PDF
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: spec/main.pdf
+          asset_name: main.pdf
+          asset_content_type: application/pdf

--- a/spec/main.tex
+++ b/spec/main.tex
@@ -60,7 +60,6 @@
 
 % tikz
 \usepackage{tikz}
-\usepackage{tikz-uml}
 \usetikzlibrary{arrows,automata,positioning}
 \usetikzlibrary{shapes.geometric}
 \usetikzlibrary{shapes.multipart}


### PR DESCRIPTION
Hey, I am tired of downloading this gigabyte repo only to build the spec. So, that's why I built a Github workflow which builds the pdf and published it as a release.

(To always get the latest PDF version, one can then simply access https://github.com/Barkhausen-Institut/TCU-if/releases/latest/download/main.pdf)

Unfortunately I had to remove the `tikz-uml` latex package ... that seem to be not included in TexLive ... however, as far as I can tell it is not used in the document and the package itself is pretty unmaintained too. 

I hope you like it.

PS: on my fork you can see how it works
https://github.com/maxkurze1/TCU-Specification/releases
https://github.com/maxkurze1/TCU-Specification/actions/runs/11355366233

